### PR TITLE
Use properly-sized slot insertion/extraction filter arrays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 dependencies {
     deobfCompile "mezz.jei:jei_${mc_version}:${jei_version}"
-    deobfCompile "mcp.mobius.waila:Hwyla:${waila_version}_1.12"
+    deobfCompile "mcp.mobius.waila:Hwyla:${waila_version}_1.12.2"
 	deobfCompile "cofh:RedstoneFlux:1.12-2.+:deobf"
 	deobfCompile "cofh:CoFHCore:${mc_version}-+:deobf"
     deobfCompile "cofh:CoFHWorld:${mc_version}-${cofh_world_version}:deobf"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ curse_id=
 mappings_version=snapshot_20171003
 
 jei_version=4.10.+
-waila_version=1.8.23-B38
+waila_version=1.8.26-B41
 cofh_world_version=1.2.0.+
 ccl_version=3.+
 tf_version=2.+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Sep 14 12:28:28 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileAnimalFarm.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileAnimalFarm.java
@@ -43,6 +43,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileAnimalFarm extends TileVirtualMachine
 {
     private static final int TYPE = Type.ANIMAL_FARM.getMetadata();
+    private static final int SLOT_COUNT = 15; // 4 + 9 + 1 + 1
     public static int basePower = 80;
 
     public static int SLOT_TOOLS_START = 0;
@@ -70,8 +71,8 @@ public class TileAnimalFarm extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { true, true, true, true, true, false, false, false, false, false, false, false, false, false };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { false, false, false, false, false, true, true, true, true, true, true, true, true, true };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 5); // tools, morb
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 5, 14); // outputs
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
         VALID_AUGMENTS[TYPE].add(VMConstants.MACHINE_EXPERIENCE);
@@ -119,7 +120,7 @@ public class TileAnimalFarm extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[15]; // 4 + 9 + 1 + 1
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(TFFluids.fluidExperience);

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileDarkRoom.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileDarkRoom.java
@@ -41,6 +41,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileDarkRoom extends TileVirtualMachine
 {
     private static final int TYPE = Type.DARK_ROOM.getMetadata();
+    private static final int SLOT_COUNT = 11; // 9 + 1 + 1 = 11
     public static int basePower = 80;
 
     public static int SLOT_SWORD = 0;
@@ -66,8 +67,8 @@ public class TileDarkRoom extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { true, false, false, false, false, false, false, false, false, false };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { false, true, true, true, true, true, true, true, true, true };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 1); // sword
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 1, 10); // outputs
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
         VALID_AUGMENTS[TYPE].add(VMConstants.MACHINE_EXPERIENCE);
@@ -109,7 +110,7 @@ public class TileDarkRoom extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[11]; // 9 + 1 + 1 = 11
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(TFFluids.fluidExperience);

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileFarm.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileFarm.java
@@ -41,6 +41,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileFarm extends TileVirtualMachine
 {
     private static final int TYPE = Type.FARM.getMetadata();
+    private static final int SLOT_COUNT = 33; // 18 + 4 + 9 + 1 + 1
     public static int basePower = 40;
 
     public static final int SLOT_TOOLS_START = 18;
@@ -65,8 +66,8 @@ public class TileFarm extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 18, 32); // tools, fertilizer, farm
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 22); // outputs, tools
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
         VALID_AUGMENTS[TYPE].add(VMConstants.MACHINE_FARM_SOIL);
@@ -110,7 +111,7 @@ public class TileFarm extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[33]; // 18 + 4 + 9 + 1 + 1
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(FluidRegistry.WATER);

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileFishery.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileFishery.java
@@ -35,6 +35,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileFishery extends TileVirtualMachine
 {
     private static final int TYPE = Type.FISHERY.getMetadata();
+    private static final int SLOT_COUNT = 12; // 1 + 1 + 9 + 1
     public static int basePower = 50;
     public static int baseFluid = 1000;
 
@@ -57,8 +58,8 @@ public class TileFishery extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { true, true, false, false, false, false, false, false, false, false, false };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { false, false, true, true, true, true, true, true, true, true, true };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 2); // rod, bait
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 2, 11); // outputs
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
 
@@ -93,7 +94,7 @@ public class TileFishery extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[12]; // 1 + 1 + 9 + 1
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(FluidRegistry.WATER);

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileMobFarm.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileMobFarm.java
@@ -39,6 +39,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileMobFarm extends TileVirtualMachine
 {
     private static final int TYPE = Type.MOB_FARM.getMetadata();
+    private static final int SLOT_COUNT = 29; // 1 + 9 + 18 + 1 = 29
     public static int basePower = 200;
 
     public static int SLOT_SWORD = 0;
@@ -65,8 +66,8 @@ public class TileMobFarm extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 10); // sword, morbs
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 1, 28); // morbs, outputs
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
         VALID_AUGMENTS[TYPE].add(VMConstants.MACHINE_EXPERIENCE);
@@ -108,7 +109,7 @@ public class TileMobFarm extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[29]; // 1 + 9 + 18 + 1 = 29
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(TFFluids.fluidExperience);

--- a/src/main/java/com/arcaratus/virtualmachines/block/machine/TileMobSpawner.java
+++ b/src/main/java/com/arcaratus/virtualmachines/block/machine/TileMobSpawner.java
@@ -41,6 +41,7 @@ import static cofh.core.util.core.SideConfig.*;
 public class TileMobSpawner extends TileVirtualMachine
 {
     private static final int TYPE = Type.MOB_SPAWNER.getMetadata();
+    private static final int SLOT_COUNT = 12; // 9 + 1 + 1 + 1 = 12
     public static int basePower = 80;
 
     public static int SLOT_SWORD = 0;
@@ -68,8 +69,8 @@ public class TileMobSpawner extends TileVirtualMachine
         ALT_SIDE_CONFIGS[TYPE].defaultSides = new byte[] { 1, 1, 1, 1, 1, 1 };
 
         SLOT_CONFIGS[TYPE] = new SlotConfig();
-        SLOT_CONFIGS[TYPE].allowInsertionSlot = new boolean[] { true, true, false, false, false, false, false, false, false, false, false };
-        SLOT_CONFIGS[TYPE].allowExtractionSlot = new boolean[] { false, true, true, true, true, true, true, true, true, true, true };
+        SLOT_CONFIGS[TYPE].allowInsertionSlot = Utils.buildFilterArray(SLOT_COUNT, 0, 2); // sword, morb
+        SLOT_CONFIGS[TYPE].allowExtractionSlot = Utils.buildFilterArray(SLOT_COUNT, 1, 11); // morb, outputs
 
         VALID_AUGMENTS[TYPE] = new HashSet<>();
         VALID_AUGMENTS[TYPE].add(VMConstants.MACHINE_EXPERIENCE);
@@ -113,7 +114,7 @@ public class TileMobSpawner extends TileVirtualMachine
     {
         super();
 
-        inventory = new ItemStack[12]; // 9 + 1 + 1 + 1 = 12
+        inventory = new ItemStack[SLOT_COUNT];
         Arrays.fill(inventory, ItemStack.EMPTY);
         createAllSlots(inventory.length);
         tank.setLock(TFFluids.fluidExperience);

--- a/src/main/java/com/arcaratus/virtualmachines/utils/Utils.java
+++ b/src/main/java/com/arcaratus/virtualmachines/utils/Utils.java
@@ -197,4 +197,17 @@ public class Utils
 
         return result;
     }
+
+    public static boolean[] buildFilterArray(int size, int... ranges)
+    {
+        if (ranges.length % 2 == 1)
+            throw new IllegalArgumentException("Unclosed range!");
+
+        boolean[] filterArray = new boolean[size];
+
+        for (int i = 0; i < ranges.length; i += 2)
+            Arrays.fill(filterArray, ranges[i], ranges[i + 1], true);
+
+        return filterArray;
+    }
 }


### PR DESCRIPTION
This should fix all the issues where using external apparatus to extract items from a virtual machine causes out-of-bounds exceptions.

This PR also bumps up the forgegradle version and the HWYLA dependency.